### PR TITLE
Harden the bower jquery dependency to exclude jquery >= 3.x.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -3,6 +3,6 @@
   "version": "2.1.2",
   "main": ["toastr.js", "toastr.css"],
   "dependencies": {
-		"jquery": ">=1.6.3"
+		"jquery": ">=1.6.3 <3"
   }
 }


### PR DESCRIPTION
As the jquery dependency is currently configured, bower will attempt to update jquery to 3.x once the production release goes live in the Bower registry. 

Jquery 3.x may not be backwards compatible with toastr 2.1.x.


